### PR TITLE
Update wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,9 +8,10 @@ zone_id = ""
 
 [build]
 command = "npm install && npm run build"
+[build.upload]
 # The "modules" upload format is required for all projects that export a Durable Objects class
-upload.format = "modules"
-upload.main = "./index.mjs"
+format = "modules"
+main = "./index.mjs"
 
 [durable_objects]
 bindings = [{name = "COUNTER", class_name = "Counter"}]


### PR DESCRIPTION
toml_edit (used by wrangler generate) doesn't support dotted table syntax, we need to always use the full table syntax in templates