### PR TITLE
Configure `exportConditions` in the Rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,7 +16,6 @@ export default {
   plugins: [
     commonjs(),
     nodeResolve({
-      // priority increases from left to right
       exportConditions: ['browser', 'worker'],
       browser: true,
     }),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,5 +13,13 @@ export default {
     file: 'dist/index.mjs',
     sourcemap: true,
   },
-  plugins: [commonjs(), nodeResolve({ browser: true }), terser()],
+  plugins: [
+    commonjs(),
+    nodeResolve({
+      // priority increases from left to right
+      exportConditions: ['browser', 'worker'],
+      browser: true,
+    }),
+    terser(),
+  ],
 }


### PR DESCRIPTION
I've noticed that this is missing and with this change the behavior of this project template would align closer to what is being described as the webpack's default [here](https://developers.cloudflare.com/workers/cli-wrangler/webpack#sensible-defaults)

Webpack handles the webworker condition automatically based on the `target: 'webworker'` (this is mentioned [here](https://webpack.js.org/guides/package-exports/#target-environment)). A side note is your webpack template defines `target: 'web'` ([here](https://github.com/cloudflare/durable-objects-webpack-commonjs/blob/25bb729f5bea83660febb86b2a6171a444f76bbb/webpack.config.js#L5)) which makes me confused as to which one is correct in context of Cloudflare Workers.

If you are not sure if this has been configured correctly - I've just created a PR for `@rollup/plugin-node-resolve` with tests that verify the priority order etc for this exact combination of `exportConditions` and `browser` options: [here](https://github.com/rollup/plugins/pull/1043)